### PR TITLE
feat: Implement business signup flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { ProtectedRoute } from "./components/ProtectedRoute";
 import Auth from "./pages/Auth";
 import Dashboard from "./pages/Dashboard";
 import Register from "./pages/Register";
+import Signup from "./pages/Signup";
 import Products from "./pages/Products";
 import AdminCategories from "./pages/admin/Categories";
 import AdminProducts from "./pages/admin/Products";
@@ -29,6 +30,7 @@ const App = () => (
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/auth" element={<Auth />} />
+            <Route path="/signup" element={<Signup />} />
             <Route path="/products" element={<Products />} />
             <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
             <Route path="/register" element={<ProtectedRoute requireAdmin><Register /></ProtectedRoute>} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Building2, Menu, X } from "lucide-react";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -28,19 +29,20 @@ const Header = () => {
             <a href="#pricing" className="text-foreground hover:text-accent transition-colors">
               Pricing
             </a>
-            <a href="#register" className="text-foreground hover:text-accent transition-colors">
-              Register
-            </a>
           </nav>
           
           {/* Desktop Actions */}
           <div className="hidden md:flex items-center gap-3">
-            <Button variant="ghost">
-              Sign In
-            </Button>
-            <Button variant="business">
-              Register Shop
-            </Button>
+            <Link to="/auth">
+              <Button variant="ghost">
+                Sign In
+              </Button>
+            </Link>
+            <Link to="/signup">
+              <Button variant="business">
+                Register Business
+              </Button>
+            </Link>
           </div>
           
           {/* Mobile Menu Button */}
@@ -69,16 +71,17 @@ const Header = () => {
               <a href="#pricing" className="text-foreground hover:text-accent transition-colors">
                 Pricing
               </a>
-              <a href="#register" className="text-foreground hover:text-accent transition-colors">
-                Register
-              </a>
               <div className="flex flex-col gap-2 pt-2">
-                <Button variant="ghost" className="justify-start">
-                  Sign In
-                </Button>
-                <Button variant="business" className="justify-start">
-                  Register Shop
-                </Button>
+                <Link to="/auth">
+                  <Button variant="ghost" className="justify-start w-full">
+                    Sign In
+                  </Button>
+                </Link>
+                <Link to="/signup">
+                  <Button variant="business" className="justify-start w-full">
+                    Register Business
+                  </Button>
+                </Link>
               </div>
             </nav>
           </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,14 +1,11 @@
 import Header from "@/components/Header";
-import RegisterSection from "@/components/RegisterSection";
 
 const Index = () => {
   return (
     <div className="min-h-screen">
       <Header />
       <main>
-        <div id="register">
-          <RegisterSection />
-        </div>
+        {/* The registration section has been removed as per the requirement to hide signup from the public homepage. */}
       </main>
     </div>
   );

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuth } from '@/hooks/useAuth';
+import { Building2, User, MapPin, Phone, Mail, Lock } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+
+const Signup = () => {
+  const { signUp } = useAuth();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    shopName: '',
+    ownerName: '',
+    phone: '',
+    email: '',
+    password: '',
+    shopLocation: ''
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData(prev => ({
+      ...prev,
+      [e.target.name]: e.target.value
+    }));
+  };
+
+  const handleSignUp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    try {
+      // Step 1: Sign up the user
+      const { data: authData, error: authError } = await signUp(formData.email, formData.password, {
+        full_name: formData.ownerName,
+        phone: formData.phone
+      });
+
+      if (authError) {
+        throw authError;
+      }
+
+      if (authData.user) {
+        // Step 2: Call the RPC to create the shop and assign the role
+        const { error: rpcError } = await supabase.rpc('create_new_shop', {
+          shop_name: formData.shopName,
+          shop_location: formData.shopLocation,
+        });
+
+        if (rpcError) {
+          throw rpcError;
+        }
+
+        toast({
+          title: "Signup Successful",
+          description: "Your account and shop have been created.",
+        });
+        navigate('/products');
+      }
+    } catch (error: any) {
+      toast({
+        title: "Signup Failed",
+        description: error.message,
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4 py-12">
+      <div className="w-full max-w-lg">
+        <div className="text-center mb-8">
+          <Building2 className="mx-auto h-12 w-12 text-primary mb-4" />
+          <h1 className="text-3xl font-bold text-foreground">Register Your Business</h1>
+          <p className="text-muted-foreground mt-2">
+            Create an account to start managing your wholesale orders
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Business Signup</CardTitle>
+            <CardDescription>Fill out the form below to create your business account.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSignUp} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="shopName">Shop Name</Label>
+                <Input
+                  id="shopName"
+                  name="shopName"
+                  value={formData.shopName}
+                  onChange={handleChange}
+                  required
+                  placeholder="e.g. City Grocers"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="ownerName">Owner Name</Label>
+                <Input
+                  id="ownerName"
+                  name="ownerName"
+                  value={formData.ownerName}
+                  onChange={handleChange}
+                  required
+                  placeholder="e.g. John Doe"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="phone">Phone Number</Label>
+                <Input
+                  id="phone"
+                  name="phone"
+                  type="tel"
+                  value={formData.phone}
+                  onChange={handleChange}
+                  required
+                  placeholder="+1234567890"
+                />
+              </div>
+               <div className="space-y-2">
+                <Label htmlFor="shopLocation">Shop Location</Label>
+                <Input
+                  id="shopLocation"
+                  name="shopLocation"
+                  value={formData.shopLocation}
+                  onChange={handleChange}
+                  required
+                  placeholder="123 Main St, Anytown, USA"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  value={formData.email}
+                  onChange={handleChange}
+                  required
+                  placeholder="owner@example.com"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  value={formData.password}
+                  onChange={handleChange}
+                  required
+                  minLength={6}
+                  placeholder="••••••••"
+                />
+              </div>
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={isLoading}
+              >
+                {isLoading ? "Signing Up..." : "Sign Up"}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Signup;

--- a/supabase/migrations/20250923144300_create_new_shop_function.sql
+++ b/supabase/migrations/20250923144300_create_new_shop_function.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION public.create_new_shop(
+  shop_name TEXT,
+  shop_location TEXT
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  new_user_id UUID := auth.uid();
+BEGIN
+  -- Insert into shops table
+  INSERT INTO public.shops (owner_id, name, location)
+  VALUES (new_user_id, shop_name, shop_location);
+
+  -- Assign business_owner role
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (new_user_id, 'business_owner');
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.create_new_shop(TEXT, TEXT) TO authenticated;


### PR DESCRIPTION
This commit introduces a new signup flow for business owners.

- Creates a new signup page at `/signup` with a form to collect shop and owner details.
- Implements a Supabase database function `create_new_shop` to securely handle the creation of the shop and assignment of the 'business_owner' role after a user signs up. This is done via an RPC call from the client.
- Updates the main header to include a "Register Business" button that links to the new signup page.
- Removes the old registration section from the homepage to hide the signup process from public view, as requested.
- The admin-only registration page at `/register` remains accessible to authenticated admins from the 'Manage Shops' page.