### PR TITLE
Add a runtime guard to the Supabase client to ensure that the require…

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -4,6 +4,15 @@ import type { Database } from './types';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
+// runtime guard for missing env variables to produce clear error
+if (!supabaseUrl || !supabaseAnonKey) {
+  // throw early so devs see a clear message instead of obscure runtime crashes
+  // This will only run in environments where the module is imported.
+  throw new Error(
+    'Missing VITE_SUPABASE_URL or VITE_SUPABASE_PUBLISHABLE_KEY. Add them to your .env (Vite) and restart the dev server.'
+  );
+}
+
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 


### PR DESCRIPTION
…d environment variables are present. This will throw an error early if the variables are missing, providing a clear message to developers.