### PR TITLE
Fix: Improve error handling for category fetching

### DIFF
--- a/src/pages/admin/Categories.tsx
+++ b/src/pages/admin/Categories.tsx
@@ -35,13 +35,17 @@ const AdminCategories = () => {
 
   const fetchCategories = async () => {
     try {
-      const { data, error } = await supabase
+      const res = await supabase
         .from('categories')
         .select('*')
         .order('code');
 
-      if (error) throw error;
-      setCategories(data || []);
+      if (res.error) {
+        console.error('Supabase categories error', res.error);
+        toast({ title: 'Failed to load categories', description: (res.error.message || String(res.error)) });
+        return;
+      }
+      setCategories(res.data || []);
     } catch (error: any) {
       toast({
         title: "Error",


### PR DESCRIPTION
This commit implements improved error handling when fetching categories from Supabase in the admin panel.

The change applies the user's requested patch to add a specific error toast message and console log when the Supabase query fails. This is merged with the existing implementation to preserve the `.order('code')` functionality and the robust `try...catch...finally` block that ensures the UI loading state is handled correctly.