### PR TITLE
Fix: Prevent infinite loading on dashboard for unauthorized users

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
@@ -37,6 +37,8 @@ const Dashboard = () => {
       fetchAdminStats();
     } else if (isBusinessOwner) {
       fetchBusinessStats();
+    } else {
+      setLoading(false);
     }
   }, [isAdmin, isBusinessOwner]);
 
@@ -97,6 +99,10 @@ const Dashboard = () => {
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
       </div>
     );
+  }
+
+  if (!isAdmin && !isBusinessOwner) {
+    return <Navigate to="/" replace />;
   }
 
   return (


### PR DESCRIPTION
The dashboard page would previously get stuck in an infinite loading state if the user was not an admin or a business owner. This was because the loading state was never updated for these users.

This commit fixes the issue by:
1.  Updating the useEffect hook in Dashboard.tsx to set the loading state to false for all users, regardless of their role.
2.  Adding a redirect to the home page for users who are not admins or business owners, preventing them from accessing the dashboard.