### PR TITLE
feat: Add user management page and role-based dashboard access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import AdminCategories from "./pages/admin/Categories";
 import AdminProducts from "./pages/admin/Products";
 import AdminOrders from "./pages/admin/Orders";
 import AdminShops from "./pages/admin/Shops";
+import AdminUsers from "./pages/admin/Users";
 import BusinessOrders from "./pages/business/Orders";
 import ItemPage from "./pages/Item";
 
@@ -45,6 +46,7 @@ const App = () => (
               <Route path="/admin/products" element={<ProtectedRoute requireAdmin><AdminProducts /></ProtectedRoute>} />
               <Route path="/admin/orders" element={<ProtectedRoute requireAdmin><AdminOrders /></ProtectedRoute>} />
               <Route path="/admin/shops" element={<ProtectedRoute requireAdmin><AdminShops /></ProtectedRoute>} />
+              <Route path="/admin/users" element={<ProtectedRoute requireAdmin><AdminUsers /></ProtectedRoute>} />
               <Route path="/cart" element={<ProtectedRoute requireBusinessOwner><Cart /></ProtectedRoute>} />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -40,9 +40,9 @@ const Dashboard = () => {
     } else {
       setLoading(false);
     }
-  }, [isAdmin, isBusinessOwner]);
+  }, [isAdmin, isBusinessOwner, fetchAdminStats, fetchBusinessStats]);
 
-  const fetchAdminStats = async () => {
+  const fetchAdminStats = useCallback(async () => {
     try {
       const [shopsResult, productsResult, ordersResult, categoriesResult] = await Promise.all([
         supabase.from('shops').select('id', { count: 'exact', head: true }),
@@ -62,9 +62,9 @@ const Dashboard = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const fetchBusinessStats = async () => {
+  const fetchBusinessStats = useCallback(async () => {
     try {
       // Get business owner's shop
       const { data: shop } = await supabase
@@ -91,7 +91,7 @@ const Dashboard = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user]);
 
   if (loading) {
     return (
@@ -218,6 +218,12 @@ const Dashboard = () => {
                     <Link to="/admin/orders">
                       <ShoppingCart className="w-4 h-4 mr-2" />
                       Manage Orders
+                    </Link>
+                  </Button>
+                  <Button asChild variant="outline" className="w-full justify-start">
+                    <Link to="/admin/users">
+                      <Users className="w-4 h-4 mr-2" />
+                      Manage Users
                     </Link>
                   </Button>
                 </CardContent>

--- a/src/pages/admin/Users.tsx
+++ b/src/pages/admin/Users.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { User } from '@supabase/supabase-js';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { toast } from '@/components/ui/use-toast';
+
+const Users = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchUsers = async () => {
+    try {
+      setLoading(true);
+      const { data: { users }, error } = await supabase.auth.admin.listUsers();
+      if (error) {
+        throw error;
+      }
+      setUsers(users || []);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        setError(error.message);
+      } else {
+        setError("An unknown error occurred");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleRoleChange = async (userId: string, newRole: string) => {
+    try {
+      const { data: { user }, error } = await supabase.auth.admin.updateUserById(
+        userId,
+        { user_metadata: { role: newRole } }
+      );
+      if (error) {
+        throw error;
+      }
+      toast({
+        title: "Success",
+        description: `User role updated to ${newRole}.`,
+      });
+      fetchUsers(); // Refresh the user list
+    } catch (error: unknown) {
+      toast({
+        title: "Error",
+        description: `Failed to update user role: ${error instanceof Error ? error.message : "An unknown error occurred"}`,
+        variant: "destructive",
+      });
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-red-500">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>User Management</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Created At</TableHead>
+                <TableHead>Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>
+                    <Badge variant={user.user_metadata?.role === 'admin' ? 'default' : 'secondary'}>
+                      {user.user_metadata?.role || 'user'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>{new Date(user.created_at).toLocaleDateString()}</TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="outline" size="sm">Change Role</Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        <DropdownMenuItem onClick={() => handleRoleChange(user.id, 'admin')}>
+                          Admin
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => handleRoleChange(user.id, 'business_owner')}>
+                          Business Owner
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => handleRoleChange(user.id, 'user')}>
+                          User
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Users;


### PR DESCRIPTION
This commit introduces a new user management page that allows admins to change user roles. It also provides a clear path for users to access the admin and business dashboards based on their roles.

The following changes are included:
- A new page at `/admin/users` to list and manage user roles.
- The route is protected and only accessible to admin users.
- The Admin Dashboard now links to the new user management page.
- Role-changing functionality is implemented using Supabase admin functions.
- Refactored data fetching in the Dashboard component to use `useCallback` and fix a linting warning.